### PR TITLE
Create module for workflows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,22 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+//! # Rust Struct for GitHub Actions Workflows
+//!
+//! [GitHub Actions](https://docs.github.com/en/actions) is a continuous integration and continuous
+//! delivery (CI/CD) platform. Users can create workflows that build, test, and deploy code:
+//!
+//! > A workflow is a configurable automated process that will run one or more jobs. Workflows are
+//! > defined by a YAML file checked in to your repository and will run when triggered by an event
+//! > in your repository, or they can be triggered manually, or at a defined schedule.
+//! > -- [GitHub Actions Documentation](https://docs.github.com/en/actions/using-workflows/about-workflows)
+//!
+//! This crate implements a representation of the [workflow syntax] that can be used to read and
+//! write the workflow files.
+//!
+//! [workflow syntax]: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+// All public items in the crate are documented using the following guidelines:
+// https://rust-lang.github.io/api-guidelines/documentation.html
+#![deny(missing_docs)]
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub use self::workflow::*;
+
+mod workflow;

--- a/src/workflow/builder.rs
+++ b/src/workflow/builder.rs
@@ -1,0 +1,52 @@
+use std::fmt::{Display, Formatter};
+
+/// Builder for Workflows
+///
+/// Workflows can be constructed using the builder pattern. The builder provides methods to set the
+/// fields of a [`Workflow`], and then a [`build`] method to construct the [`Workflow`]. The method
+/// returns a [`Result`] that is [`Ok`] if the [`Workflow`] was successfully constructed, and an
+/// [`Err`] if mandatory fields for the the [`Workflow`] were missing.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct WorkflowBuilder {}
+
+impl WorkflowBuilder {
+    /// Create a new WorkflowBuilder
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Display for WorkflowBuilder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WorkflowBuilder")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_display() {
+        let workflow_builder = WorkflowBuilder {};
+        assert_eq!("WorkflowBuilder", workflow_builder.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<WorkflowBuilder>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<WorkflowBuilder>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<WorkflowBuilder>();
+    }
+}

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -1,0 +1,56 @@
+use std::fmt::{Display, Formatter};
+
+pub use self::builder::WorkflowBuilder;
+
+mod builder;
+
+/// # A GitHub Actions Workflow
+///
+/// A workflow is a configurable automated process that will run one or more jobs. Workflows are
+/// defined by a YAML file checked in to your repository and will run when triggered by an event in
+/// your repository, or they can be triggered manually, or at a defined schedule.
+///
+/// Workflows are defined in the `.github/workflows` directory in a repository, and a repository can
+/// have multiple workflows, each of which can perform a different set of tasks. For example, you
+/// can have one workflow to build and test pull requests, another workflow to deploy your
+/// application every time a release is created, and still another workflow that adds a label every
+/// time someone opens a new issue.
+///
+/// -- [GitHub Actions Documentation](https://docs.github.com/en/actions/using-workflows/about-workflows)
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Workflow {}
+
+impl Display for Workflow {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Workflow")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_display() {
+        let workflow = Workflow {};
+        assert_eq!("Workflow", workflow.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Workflow>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Workflow>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Workflow>();
+    }
+}

--- a/tests/workflow.rs
+++ b/tests/workflow.rs
@@ -1,0 +1,11 @@
+use gh_workflow::{Workflow, WorkflowBuilder};
+
+#[test]
+fn builder() {
+    let _builder = WorkflowBuilder::new();
+}
+
+#[test]
+fn workflow() {
+    let _workflow = Workflow::default();
+}


### PR DESCRIPTION
A new module has been created for workflows. The module contains the `Workflow` struct, which represents a GitHub Actions workflow, and a `WorkflowBuilder`, which can be used to construct workflows. Both are empty, since no fields have been added to the workflow yet.