### PR TITLE
Add field name to workflow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,4 +19,5 @@
 
 pub use self::workflow::*;
 
+mod macros;
 mod workflow;

--- a/src/workflow/builder.rs
+++ b/src/workflow/builder.rs
@@ -1,3 +1,4 @@
+use crate::WorkflowName;
 use std::fmt::{Display, Formatter};
 
 /// Builder for Workflows
@@ -6,19 +7,30 @@ use std::fmt::{Display, Formatter};
 /// fields of a [`Workflow`], and then a [`build`] method to construct the [`Workflow`]. The method
 /// returns a [`Result`] that is [`Ok`] if the [`Workflow`] was successfully constructed, and an
 /// [`Err`] if mandatory fields for the the [`Workflow`] were missing.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-pub struct WorkflowBuilder {}
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct WorkflowBuilder {
+    name: Option<WorkflowName>,
+}
 
 impl WorkflowBuilder {
-    /// Create a new WorkflowBuilder
+    /// Creates a new WorkflowBuilder
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Sets the name of the workflow
+    pub fn name(mut self, name: WorkflowName) -> Self {
+        self.name = Some(name);
+        self
     }
 }
 
 impl Display for WorkflowBuilder {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "WorkflowBuilder")
+        match &self.name {
+            Some(name) => write!(f, "WorkflowBuilder for {}", name),
+            None => write!(f, "WorkflowBuilder"),
+        }
     }
 }
 
@@ -27,8 +39,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn trait_display() {
-        let workflow_builder = WorkflowBuilder {};
+    fn trait_display_with_name() {
+        let workflow_builder = WorkflowBuilder {
+            name: Some("workflow".into()),
+        };
+
+        assert_eq!("WorkflowBuilder for workflow", workflow_builder.to_string());
+    }
+
+    #[test]
+    fn trait_display_without_name() {
+        let workflow_builder = WorkflowBuilder::new();
+
         assert_eq!("WorkflowBuilder", workflow_builder.to_string());
     }
 

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -1,5 +1,7 @@
 use std::fmt::{Display, Formatter};
 
+use crate::name;
+
 pub use self::builder::WorkflowBuilder;
 
 mod builder;
@@ -17,12 +19,38 @@ mod builder;
 /// time someone opens a new issue.
 ///
 /// -- [GitHub Actions Documentation](https://docs.github.com/en/actions/using-workflows/about-workflows)
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-pub struct Workflow {}
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Workflow {
+    name: Option<WorkflowName>,
+}
+
+name!(
+    /// # The name of a workflow
+    ///
+    /// GitHub displays the names of your workflows on your repository's "Actions" tab. If you omit
+    /// it, GitHub sets it to the workflow file path relative to the root of the repository.
+    WorkflowName
+);
+
+impl Workflow {
+    /// Returns the name of the workflow
+    pub fn name(&self) -> &Option<WorkflowName> {
+        &self.name
+    }
+
+    /// Sets the name of the workflow
+    pub fn set_name(&mut self, name: WorkflowName) {
+        self.name = Some(name);
+    }
+}
 
 impl Display for Workflow {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Workflow")
+        if let Some(name) = &self.name {
+            return write!(f, "{}", name);
+        }
+
+        write!(f, "<unnamed workflow>")
     }
 }
 
@@ -31,9 +59,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn trait_display() {
-        let workflow = Workflow {};
-        assert_eq!("Workflow", workflow.to_string());
+    fn name() {
+        let workflow = Workflow {
+            name: Some("workflow".into()),
+        };
+
+        assert_eq!(&Some(WorkflowName::new("workflow")), workflow.name());
+    }
+
+    #[test]
+    fn set_name() {
+        let mut workflow = Workflow { name: None };
+
+        workflow.set_name(WorkflowName::new("workflow"));
+
+        assert_eq!(&Some(WorkflowName::new("workflow")), workflow.name());
+    }
+
+    #[test]
+    fn trait_display_with_name() {
+        let workflow = Workflow {
+            name: Some("workflow".into()),
+        };
+
+        assert_eq!("workflow", workflow.to_string());
+    }
+
+    #[test]
+    fn trait_display_without_name() {
+        let workflow = Workflow { name: None };
+
+        assert_eq!("<unnamed workflow>", workflow.to_string());
     }
 
     #[test]


### PR DESCRIPTION
Users can give workflows a name, which will be shown in the user interface of GitHub in various places. A new field called `name` has been added to the `Workflow` struct that represents this name.