### PR TITLE
Add field run-name to workflow

### DIFF
--- a/src/workflow/builder.rs
+++ b/src/workflow/builder.rs
@@ -1,5 +1,6 @@
-use crate::WorkflowName;
 use std::fmt::{Display, Formatter};
+
+use crate::{WorkflowName, WorkflowRunName};
 
 /// Builder for Workflows
 ///
@@ -10,6 +11,7 @@ use std::fmt::{Display, Formatter};
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct WorkflowBuilder {
     name: Option<WorkflowName>,
+    run_name: Option<WorkflowRunName>,
 }
 
 impl WorkflowBuilder {
@@ -21,6 +23,12 @@ impl WorkflowBuilder {
     /// Sets the name of the workflow
     pub fn name(mut self, name: WorkflowName) -> Self {
         self.name = Some(name);
+        self
+    }
+
+    /// Sets the run-name of the workflow
+    pub fn run_name(mut self, run_name: WorkflowRunName) -> Self {
+        self.run_name = Some(run_name);
         self
     }
 }
@@ -39,9 +47,28 @@ mod tests {
     use super::*;
 
     #[test]
+    fn name() {
+        let mut builder = WorkflowBuilder::new();
+
+        builder = builder.name(WorkflowName::new("workflow"));
+
+        assert_eq!(Some(WorkflowName::new("workflow")), builder.name);
+    }
+
+    #[test]
+    fn run_name() {
+        let mut builder = WorkflowBuilder::new();
+
+        builder = builder.run_name(WorkflowRunName::new("workflow"));
+
+        assert_eq!(Some(WorkflowRunName::new("workflow")), builder.run_name);
+    }
+
+    #[test]
     fn trait_display_with_name() {
         let workflow_builder = WorkflowBuilder {
             name: Some("workflow".into()),
+            ..Default::default()
         };
 
         assert_eq!("WorkflowBuilder for workflow", workflow_builder.to_string());

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -22,6 +22,7 @@ mod builder;
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Workflow {
     name: Option<WorkflowName>,
+    run_name: Option<WorkflowRunName>,
 }
 
 name!(
@@ -30,6 +31,16 @@ name!(
     /// GitHub displays the names of your workflows on your repository's "Actions" tab. If you omit
     /// it, GitHub sets it to the workflow file path relative to the root of the repository.
     WorkflowName
+);
+
+name!(
+    /// # The name for workflow runs generated from the workflow
+    ///
+    /// GitHub displays the workflow run name in the list of workflow runs on your repository's
+    /// "Actions" tab. If `run-name` is omitted or is only whitespace, then the run name is set to
+    /// event-specific information for the workflow run. For example, for a workflow triggered by a
+    /// `push` or `pull_request` event, it is set as the commit message.
+    WorkflowRunName
 );
 
 impl Workflow {
@@ -41,6 +52,16 @@ impl Workflow {
     /// Sets the name of the workflow
     pub fn set_name(&mut self, name: WorkflowName) {
         self.name = Some(name);
+    }
+
+    /// Returns the run-name of the workflow
+    pub fn run_name(&self) -> &Option<WorkflowRunName> {
+        &self.run_name
+    }
+
+    /// Sets the run-name of the workflow
+    pub fn set_run_name(&mut self, run_name: WorkflowRunName) {
+        self.run_name = Some(run_name);
     }
 }
 
@@ -62,6 +83,7 @@ mod tests {
     fn name() {
         let workflow = Workflow {
             name: Some("workflow".into()),
+            ..Default::default()
         };
 
         assert_eq!(&Some(WorkflowName::new("workflow")), workflow.name());
@@ -69,7 +91,10 @@ mod tests {
 
     #[test]
     fn set_name() {
-        let mut workflow = Workflow { name: None };
+        let mut workflow = Workflow {
+            name: None,
+            ..Default::default()
+        };
 
         workflow.set_name(WorkflowName::new("workflow"));
 
@@ -77,9 +102,32 @@ mod tests {
     }
 
     #[test]
+    fn run_name() {
+        let workflow = Workflow {
+            run_name: Some("workflow".into()),
+            ..Default::default()
+        };
+
+        assert_eq!(&Some(WorkflowRunName::new("workflow")), workflow.run_name());
+    }
+
+    #[test]
+    fn set_run_name() {
+        let mut workflow = Workflow {
+            run_name: None,
+            ..Default::default()
+        };
+
+        workflow.set_run_name(WorkflowRunName::new("workflow"));
+
+        assert_eq!(&Some(WorkflowRunName::new("workflow")), workflow.run_name());
+    }
+
+    #[test]
     fn trait_display_with_name() {
         let workflow = Workflow {
             name: Some("workflow".into()),
+            ..Default::default()
         };
 
         assert_eq!("workflow", workflow.to_string());
@@ -87,7 +135,10 @@ mod tests {
 
     #[test]
     fn trait_display_without_name() {
-        let workflow = Workflow { name: None };
+        let workflow = Workflow {
+            name: None,
+            ..Default::default()
+        };
 
         assert_eq!("<unnamed workflow>", workflow.to_string());
     }

--- a/tests/workflow.rs
+++ b/tests/workflow.rs
@@ -2,7 +2,9 @@ use gh_workflow::{Workflow, WorkflowBuilder};
 
 #[test]
 fn builder() {
-    let _builder = WorkflowBuilder::new();
+    let _builder = WorkflowBuilder::new()
+        .name("workflow".into())
+        .run_name("triggered by test".into());
 }
 
 #[test]


### PR DESCRIPTION
Users can set the `run-name` for a workflow, which is used as the name for workflow runs generated from the workflow. A new field called `run-name` has been added to the `Workflow` struct that represents this name.